### PR TITLE
Add Catalan numbers

### DIFF
--- a/dynamic_programming/catalan_numbers.nim
+++ b/dynamic_programming/catalan_numbers.nim
@@ -1,0 +1,105 @@
+# Catalan Numbers
+#[  
+    The Catalan numbers are a sequence of natural numbers that occur in the 
+    most large set of combinatorial problems.
+    For example, it describes:
+    - the number of ways to parenthesize a product of n factors
+    - the number of ways to form a binary search tree with n+1 leaves
+    - the number of Dyck paths of length 2n
+    - the number of ways to triangulate a convex polygon with n+2 sides
+    References:
+    https://en.wikipedia.org/wiki/Catalan_number
+    https://oeis.org/A000108
+]#
+import math
+{.push raises: [].}
+
+func catalanNumbersRecursive(index: Natural): Positive =
+  ## Returns the index-th Catalan number recursively.
+  ## As Nim does not make automatic memoization, this function is not
+  ## efficient.
+  if index == 0:
+    return 1
+  for i in 0 ..< index:
+    result += catalan_numbers_recursive(i) *
+     catalan_numbers_recursive(index - i - 1)
+
+func catalanNumbersRecursive2(index: Natural): Positive =
+  if index == 0:
+    return 1
+  else:
+    2 * (2 * index - 1) * catalanNumbersRecursive2(index - 1) div (index + 1)
+
+func catalanNumbers(index_limit: Natural): seq[Positive] =
+  ## Returns all Catalan numbers up to the index-th number iteratively.
+  var catalan_numbers = newSeq[Positive](index_limit + 1)
+  catalan_numbers[0] = 1
+  for i in 1 .. index_limit:
+    for j in 0 ..< i:
+      catalan_numbers[i] += catalan_numbers[j] * catalan_numbers[i - j - 1]
+  catalan_numbers
+
+func catalanNumbers2(index: Natural): Positive =
+  ## Returns the index-th Catalan number iteratively with a second formula.
+  ## This function is not efficient.
+  binom(2 * index, index) div (index + 1)
+
+iterator catalanNumbersIt(index: Natural): Positive =
+  ## Iterates over all Catalan numbers up to the index-th number.
+  var catalan_numbers_lst = newSeq[Positive](index + 1)
+  catalan_numbers_lst[0] = 1
+  yield 1
+  for i in 1 .. index:
+    for j in 0 ..< i:
+      catalan_numbers_lst[i] += catalan_numbers_lst[j] * catalan_numbers_lst[i - j - 1]
+    yield catalan_numbers_lst[i]
+
+func createCatalanTable(N: static[Natural]): array[N, Positive] =
+  ## Creates a table of Catalan numbers up to the 37th number.
+  if N > 36:
+    raise newException(OverflowDefect, "N must be less than 36")
+  result[0] = 1
+  for i in 1 ..< N:
+    for j in 0 ..< i:
+      result[i] += result[j] * result[i - j - 1]
+
+func catalanNumber(index: Natural): Positive =
+  when sizeof(int) == 2:
+    const catalanTable = createCatalanTable(12)
+  when sizeof(int) == 4:
+    const catalanTable = createCatalanTable(20)
+  when sizeof(int) == 8: 
+    const catalanTable = createCatalanTable(36)
+  catalanTable[index-1]
+
+when isMainModule:
+  import std/unittest
+
+  let expectedResult: seq[Positive] = @[1, 1, 2, 5, 14, 42, 132, 429,
+                                        1430, 4862, 16796, 58786, 208012,
+                                        742900, 2674440, 9694845]
+  const catalanNumbersLst = [1, 1, 2, 5, 14, 42, 132, 429, 1430, 4862, 16796,
+    58786, 208012, 742900, 2674440, 9694845, 35357670, 129644790, 477638700,
+    1767263190, 6564120420, 24466267020, 91482563640, 343059613650,
+    1289904147324, 4861946401452, 18367353072152, 69533550916004,
+    263747951750360, 1002242216651368, 3814986502092304, 14544636039226909,
+    55534064877048198, 212336130412243110, 812944042149730764,
+    3116285494907301262]
+  
+  static:
+    for i in 0 ..< 36:
+      doAssert (catalanNumbersLst[i] == createCatalanTable(36)[i])
+
+  suite "Catalan Numbers":
+    test "The twelve first Catalan numbers":
+      check catalan_numbers(15) == expectedResult
+    
+    test "The sixteen first Catalan numbers with iterator":
+      let n = 15
+      var i = 0
+      for catalan_number in catalan_numbers_it(n):
+        check catalan_number == expectedResult[i]
+        inc i
+    
+    test "Uses compile-time table":
+      check catalan_number(36) == Positive(3116285494907301262)


### PR DESCRIPTION
I have implemented all formulas to compute Catalan Numbers and have given a compile-time table computation.
I have also implemented an iterator version.
It might be too much, please let me know what you want to keep.

For comparison, I link below the existing implementations:
Math version: https://the-algorithms.com/algorithm/catalan-number
Dynamic programming: https://the-algorithms.com/algorithm/catalan-numbers
On Rosetta Code: https://rosettacode.org/wiki/Catalan_numbers