### PR TITLE
chore: add `config.nims` with nim defaults & chore tasks

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,50 @@
+# Nim compilation defaults for the whole repository
+--gc: arc
+if defined(release) or defined(danger):
+  --opt: speed
+  --passC: "-flto"
+  --passL: "-flto"
+  --passL: "-s"
+else:
+  --checks: on
+  --assertions: on
+  --spellSuggest
+  --styleCheck: error
+
+import std/[os, sequtils]
+from std/strutils import startsWith, endsWith
+from std/strformat import `&`
+
+const IgnorePathPrefixes = [".", "scripts"]
+
+func isIgnored(path: string): bool =
+  IgnorePathPrefixes.mapIt(path.startsWith(it)).anyIt(it)
+
+iterator modules(dir: string = getCurrentDir()): string =
+  ## Iterate over paths to all nim files in directory `dir`, skipping
+  ## paths starting with substrings from the `IgnorePathPrefixes` const
+  for path in walkDirRec(dir, relative = true):
+    if not path.isIgnored() and path.endsWith(".nim"):
+      yield path
+
+############ Tasks
+task test, "Test everything":
+  --hints: off
+  var failedUnits: seq[string]
+
+  for path in modules():
+    echo &"Testing {path}:"
+    try: exec(&"nim --hints:off r \"{path}\"")
+    except OSError:
+      failedUnits.add(path)
+  if failedUnits.len > 0:
+    echo "Failed tests:"
+    for path in failedUnits:
+      echo &"- {path}"
+    quit(1)
+  else:
+    echo "All tests passed successfully"
+
+task prettyfy, "Run nimpretty on everything":
+  for path in modules():
+    exec(&"nimpretty \"{path}\"")


### PR DESCRIPTION
This PR adds a `config.nims` that provides:
- A few compiler defaults (some of them based on PR #20) .
- A Nim task `test` to run all the units in the repo as executables, with an assumption it runs tests. Task runs with `nim test`.
  This task is a proposed replacement for the shell scripts from PR #20.
  Main benefits over Bash: cross-platform, no additional dependencies.
- A Nim task `prettyfy` ro run `nimpretty` on all *.nim files in the repository. Task runs with `nim prettyfy`
  This task is a proposed replacement for the shell script from PR #19.

List of compiler defaults:
```nim
--gc:arc
--checks:on
--assertions:on
--spellSuggest
--styleCheck:error
```