### PR TITLE
chore: run `apt-get update` before running other commands

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,6 +1,6 @@
 FROM gitpod/workspace-base
 
-RUN curl https://nim-lang.org/choosenim/init.sh -sSf -o install_nim.sh \
+RUN sudo apt-get update && curl https://nim-lang.org/choosenim/init.sh -sSf -o install_nim.sh \
     && chmod +x ./install_nim.sh \
     && ./install_nim.sh -y \
     && rm install_nim.sh \


### PR DESCRIPTION
Things added/changed:

- Run `sudo apt-get update` before running other commands on the Gitpod Dockerfile.
