### PR TITLE
chore: `gc`->`mm`, move back to `config.nims`, fixes #26

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -13,6 +13,8 @@ import std/[os, sequtils]
 from std/strutils import startsWith, endsWith
 from std/strformat import `&`
 
+--mm:arc # TODO: check if still needs to be below imports on Nim > 1.6.12
+
 const IgnorePathPrefixes = ["."]
 
 func isIgnored(path: string): bool =
@@ -27,12 +29,13 @@ iterator modules(dir: string = getCurrentDir()): string =
 
 ############ Tasks
 task test, "Test everything":
+  --warning: "BareExcept:off"
   --hints: off
   var failedUnits: seq[string]
 
   for path in modules():
     echo &"Testing {path}:"
-    try: exec(&"nim --hints:off r \"{path}\"")
+    try: selfExec(&"-f --warning[BareExcept]:off --hints:off r \"{path}\"")
     except OSError:
       failedUnits.add(path)
   if failedUnits.len > 0:

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,2 +1,0 @@
-# Nim compilation defaults for the whole repository
---gc: arc


### PR DESCRIPTION
Fixes #26 and removes the now unused `nim.cfg`

Setting the `mm`/`gc` switch turned out to be position-sensitive. Moving it below the imports helps. Will not be necessary as soon as the fixes from devel land in the stable compiler branch. The switch is renamed to the not deprecated `mm` version.

This also silences the `BareExcept` warning when running tests with `nim test` that mostly stem from the `std/unittest`. The used compiler switch (`warning[BareExcept]:off`) surprisingly works fine on stable but didn't work reliably on devel (should be fixed with nim-lang/Nim/pull/21390 by now).