### PR TITLE
docs: add missing `#`

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -10,7 +10,7 @@
 ## Maths
   * [Absolute value](maths/abs.nim)
   * [Aliquot sum](maths/aliquot_sum.nim)
-  * [Arc Length](maths/arc_length.nim)
+  * [Arc Length of a Circle](maths/arc_length.nim)
   * [Bitwise Addition](maths/bitwise_addition.nim)
 
 ## Searches

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -10,7 +10,7 @@
 ## Maths
   * [Absolute value](maths/abs.nim)
   * [Aliquot sum](maths/aliquot_sum.nim)
-  * [Arc Length of a Circle](maths/arc_length.nim)
+  * [Arc Length](maths/arc_length.nim)
   * [Bitwise Addition](maths/bitwise_addition.nim)
 
 ## Searches

--- a/dynamic_programming/catalan_numbers.nim
+++ b/dynamic_programming/catalan_numbers.nim
@@ -1,4 +1,4 @@
-# Catalan Numbers
+## Catalan Numbers
 #[
     The Catalan numbers are a sequence of natural numbers that occur in the
     most large set of combinatorial problems.

--- a/dynamic_programming/viterbi.nim
+++ b/dynamic_programming/viterbi.nim
@@ -1,4 +1,4 @@
-# Viterbi
+## Viterbi
 {.push raises: [].}
 
 type

--- a/maths/arc_length.nim
+++ b/maths/arc_length.nim
@@ -1,4 +1,4 @@
-## Arc Length of a Circle
+## Arc Length
 ## https://en.wikipedia.org/wiki/Arc_length
 import std/math
 {.push raises: [].}

--- a/maths/arc_length.nim
+++ b/maths/arc_length.nim
@@ -1,4 +1,4 @@
-# Arc Length of a Circle
+## Arc Length of a Circle
 ## https://en.wikipedia.org/wiki/Arc_length
 import std/math
 {.push raises: [].}


### PR DESCRIPTION
This PR adds a missing `#` in the `module-level documentation` in changed `*.nim` files. It not only adapts these files to the [contributing guidelines](https://github.com/vil02/Nim/blob/17c4c39a31e2e0e56110d9117ba2c5d4d8916e20/CONTRIBUTING.md) but also removes the warnings when executing `nim r .scripts/directory.nim`.