### PR TITLE
chore: use nim 1.6.14

### DIFF
--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '1.6.12'
+          - '1.6.14'
 
     steps:
       - uses: actions/checkout@v3

--- a/config.nims
+++ b/config.nims
@@ -13,7 +13,7 @@ import std/[os, sequtils]
 from std/strutils import startsWith, endsWith
 from std/strformat import `&`
 
---mm:arc # TODO: check if still needs to be below imports on Nim > 1.6.12
+--mm:arc # TODO: check if still needs to be below imports on Nim > 1.6.14
 
 const IgnorePathPrefixes = ["."]
 


### PR DESCRIPTION
Since [Nim 1.6.14 was released](https://nim-lang.org/blog/2023/06/27/version-1614-released.html) I suggest to use it in [nim_test.yml](https://github.com/TheAlgorithms/Nim/blob/510b70c01dc3f2f653bcbaf00896d7ea1c8db6f2/.github/workflows/nim_test.yml).

Regarding
https://github.com/TheAlgorithms/Nim/blob/510b70c01dc3f2f653bcbaf00896d7ea1c8db6f2/config.nims#L16
when I move this _above the imports_ I get:
```
/home/userName/.choosenim/toolchains/nim-1.6.14/lib/pure/parseutils.nim(426, 21) Error: system module needs: nimDestroyAndDispose
```
