### PR TITLE
style: use `$HOME` in nim path

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -4,4 +4,4 @@ RUN curl https://nim-lang.org/choosenim/init.sh -sSf -o install_nim.sh \
     && chmod +x ./install_nim.sh \
     && ./install_nim.sh -y \
     && rm install_nim.sh \
-    && echo "export PATH=/home/$(whoami)/.nimble/bin:\$PATH" >> ~/.bashrc
+    && echo "export PATH=$HOME/.nimble/bin:\$PATH" >> ~/.bashrc


### PR DESCRIPTION
This PR simplifies the `.gitpod.dockerfile` by using `$HOME` for _constructing_ the path, where `nim` is.