### PR TITLE
fix: resolve `ProveInit` error in `catalanNumbersRecursive`

### DIFF
--- a/dynamic_programming/catalan_numbers.nim
+++ b/dynamic_programming/catalan_numbers.nim
@@ -12,6 +12,7 @@
     https://oeis.org/A000108
 ]#
 import std/math
+import std/sequtils
 {.push raises: [].}
 
 func catalanNumbersRecursive(index: Natural): Positive =
@@ -20,9 +21,8 @@ func catalanNumbersRecursive(index: Natural): Positive =
   ## efficient.
   if index < 2:
     return 1
-  for i in 0 ..< index:
-    result += catalanNumbersRecursive(i) *
-     catalanNumbersRecursive(index - i - 1)
+  return toSeq(0..<index).mapIt(catalanNumbersRecursive(it) *
+   catalanNumbersRecursive(index - it - 1)).foldl(a + b)
 
 func catalanNumbersRecursive2(index: Natural): Positive =
   if index < 2:

--- a/dynamic_programming/catalan_numbers.nim
+++ b/dynamic_programming/catalan_numbers.nim
@@ -21,8 +21,6 @@ func catalanNumbersRecursive(index: Natural): Positive =
   ## efficient.
   if index < 2:
     return 1
-  if index < 2:
-    return 1
   var n: Natural = 0
   for i in 0 ..< index:
     n += catalanNumbersRecursive(i) * catalanNumbersRecursive(index - i - 1)

--- a/dynamic_programming/catalan_numbers.nim
+++ b/dynamic_programming/catalan_numbers.nim
@@ -21,8 +21,12 @@ func catalanNumbersRecursive(index: Natural): Positive =
   ## efficient.
   if index < 2:
     return 1
-  return toSeq(0..<index).mapIt(catalanNumbersRecursive(it) *
-   catalanNumbersRecursive(index - it - 1)).foldl(a + b)
+  if index < 2:
+    return 1
+  var n: Natural = 0
+  for i in 0 ..< index:
+    n += catalanNumbersRecursive(i) * catalanNumbersRecursive(index - i - 1)
+  n
 
 func catalanNumbersRecursive2(index: Natural): Positive =
   if index < 2:


### PR DESCRIPTION
Since `devel` has become `1.9.5`, the [`nim_test_cyclic`](https://github.com/TheAlgorithms/Nim/blob/231960bd4d8d96a020ce34c82f066edb61510fbf/.github/workflows/nim_test_cyclic.yml) is failing, with the error (cf. [log](https://github.com/TheAlgorithms/Nim/actions/runs/5709792795/job/15469089378)):
```
Testing dynamic_programming/catalan_numbers.nim:
/home/runner/work/Nim/Nim/dynamic_programming/catalan_numbers.nim(24, 5) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
/home/runner/work/Nim/Nim/dynamic_programming/catalan_numbers.nim(18, 3) Error: 'result' requires explicit initialization
```

This `PR` fixes this issue ~~with an aid of [`std/sequtils`](https://nim-lang.org/docs/sequtils.html) (cf. [log](https://github.com/vil02/Nim/actions/runs/5942297864))~~ (cf. [log](https://github.com/vil02/Nim/actions/runs/5943721363)).

Please note that merging this will allow to update the Nim version in [nim_test](https://github.com/TheAlgorithms/Nim/blob/231960bd4d8d96a020ce34c82f066edb61510fbf/.github/workflows/nim_test.yml) to `2.0.0` (cf. [Nim v2.0 released](https://nim-lang.org/blog/2023/08/01/nim-v20-released.html)).
