### PR TITLE
chore: use nim 2.0.0

### DIFF
--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '1.6.14'
+          - '2.0.0'
 
     steps:
       - uses: actions/checkout@v3

--- a/config.nims
+++ b/config.nims
@@ -9,11 +9,11 @@ else:
   --spellSuggest
   --styleCheck: error
 
+--mm:arc
+
 import std/[os, sequtils]
 from std/strutils import startsWith, endsWith
 from std/strformat import `&`
-
---mm:arc # TODO: check if still needs to be below imports on Nim > 1.6.14
 
 const IgnorePathPrefixes = ["."]
 


### PR DESCRIPTION
As mentioned in #55, it is possible to use the nim version 2.0.0 in [`nim_test`](https://github.com/TheAlgorithms/Nim/blob/9f045f79cd4a81fc08efe67f04158d92712f08e1/.github/workflows/nim_test.yml) workflow (cf. [Nim v2.0 released](https://nim-lang.org/blog/2023/08/01/nim-v20-released.html)).

When nim version is updated, it is also possible to _move_ `--mm:arc` _above_ imports in https://github.com/TheAlgorithms/Nim/blob/9f045f79cd4a81fc08efe67f04158d92712f08e1/config.nims#L16