### PR TITLE
chore: update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -14,7 +14,7 @@ jobs:
     name: check format code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -23,7 +23,7 @@ jobs:
           - '2.0.0'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: jiro4989/setup-nim-action@v1
         with:

--- a/.github/workflows/nim_test_cyclic.yml
+++ b/.github/workflows/nim_test_cyclic.yml
@@ -20,7 +20,7 @@ jobs:
           - 'devel'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: jiro4989/setup-nim-action@v1
         with:


### PR DESCRIPTION
The `actions/checkout@v4` was recently [released](https://github.com/actions/checkout/releases/tag/v4.0.0).