### PR TITLE
style: remove unused import in `catalan_numbers.nim`

### DIFF
--- a/dynamic_programming/catalan_numbers.nim
+++ b/dynamic_programming/catalan_numbers.nim
@@ -12,7 +12,6 @@
     https://oeis.org/A000108
 ]#
 import std/math
-import std/sequtils
 {.push raises: [].}
 
 func catalanNumbersRecursive(index: Natural): Positive =


### PR DESCRIPTION
[`std/sequtils`](https://github.com/TheAlgorithms/Nim/blob/ac2b056645f550994a9ca9e67038f55d4fe262ba/dynamic_programming/catalan_numbers.nim#L15) are [unused](https://github.com/TheAlgorithms/Nim/actions/runs/6765358794/job/18384910968#step:5:44). This PR fixes that.