### PR TITLE
chore: run `nimpretty` with `--indent:2`

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -48,4 +48,4 @@ task test, "Test everything":
 
 task prettyfy, "Run nimpretty on everything":
   for path in modules():
-    exec(&"nimpretty \"{path}\"")
+    exec(&"nimpretty --indent:2 \"{path}\"")


### PR DESCRIPTION
As pointed out by @ZoomRmc in https://github.com/TheAlgorithms/Nim/pull/62#pullrequestreview-1737253041 this projects uses uses 2-space indentation. However, the [current](https://github.com/TheAlgorithms/Nim/blob/ac2b056645f550994a9ca9e67038f55d4fe262ba/config.nims#L51) setup accepts files with 4-space indentation. This PR is an attempt to fix that.