### PR TITLE
chore: use nim version `2.0.2`

### DIFF
--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '2.0.0'
+          - '2.0.2'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[Nim 2.0.2](https://nim-lang.org/blog/2023/12/19/versions-1618-202-released.html) was released. This PR makes a suitable update.