### PR TITLE
chore: use nim version `2.0.8`

### DIFF
--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '2.0.4'
+          - '2.0.8'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '2.0.2'
+          - '2.0.4'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[Nim 2.0.4](https://nim-lang.org/blog/2024/04/16/versions-1620-204-released.html) and [Nim 2.0.8](https://nim-lang.org/blog/2024/07/03/version-208-released.html) was relleased. This PR makes a suitable update.

Similar to #67. 