### PR TITLE
Fix check code format

### DIFF
--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Format code
         run: |
+          echo ".nim_runtime" >> .gitignore
           git clean -f -x -d
           nim prettyfy
 


### PR DESCRIPTION
The latest update of setup-nim-action puts the Nim executable in a directory called `.nim_runtime`.
The workflow `check code format` removed this directory through a git command.

I propose to git ignore this directory.
Another possibility would be to update the git option flags.
