### PR TITLE
Fix check code format wf

### DIFF
--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -27,9 +27,12 @@ jobs:
 
       - name: Fail if needs reformatting
         run: |
+          echo ".nim_runtime" > .gitignore
           if [[ $(git status --porcelain) ]]; then
              echo "please reformat/prettyfy these files:"
              git status --porcelain=v1
+             rm -vf .gitignore
              exit 1
           fi
+          rm -vf .gitignore
 ...

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -19,11 +19,14 @@ jobs:
           fetch-depth: 0
 
       - uses: jiro4989/setup-nim-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          nim-install-directory: ${{ runner.temp }}
 
       - name: Format code
         run: |
-          git clean -f -x -d -e ".nim_runtime"
-          nim prettyfy --excludePath=".nim_runtime"
+          git clean -f -x -d
+          nim prettyfy
 
       - name: Fail if needs reformatting
         run: |

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           nim-version: '2.0.8'  # default is stable
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          nim-install-directory: ${{ runner.temp }}/nim-runtime
+          nim-install-directory: /home/runner/work/_temp/.nim-runtime
 
       - name: Format code
         run: |

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           nim-version: '2.0.8'  # default is stable
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          nim-install-directory: ${{ runner.temp }}
+          nim-install-directory: ${{ runner.temp }}/nim-runtime
 
       - name: Format code
         run: |

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -23,16 +23,13 @@ jobs:
       - name: Format code
         run: |
           git clean -f -x -d -e ".nim_runtime"
-          nim prettyfy
+          nim prettyfy --excludePath=".nim_runtime"
 
       - name: Fail if needs reformatting
         run: |
-          echo ".nim_runtime" > .gitignore
           if [[ $(git status --porcelain) ]]; then
              echo "please reformat/prettyfy these files:"
              git status --porcelain=v1
-             rm -vf .gitignore
              exit 1
           fi
-          rm -vf .gitignore
 ...

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           nim-version: '2.0.8'  # default is stable
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          nim-install-directory: /home/runner/work/_temp/.nim-runtime
+          nim-install-directory: /home/runner/
 
       - name: Format code
         run: |

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -20,9 +20,9 @@ jobs:
 
       - uses: jiro4989/setup-nim-action@v2
         with:
-          nim-version: '2.0.8'  # default is stable
+          nim-version: stable
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          parent-nim-install-directory: /home/runner/
+          parent-nim-install-directory: ${{ runner.temp }}
 
       - name: Format code
         run: |

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: jiro4989/setup-nim-action@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          nim-install-directory: ${{ runner.temp }}
+          nim-install-directory: ${{ runner.temp }}/nim_runtime
 
       - name: Format code
         run: |

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -22,8 +22,7 @@ jobs:
 
       - name: Format code
         run: |
-          echo ".nim_runtime" >> .gitignore
-          git clean -f -x -d
+          git clean -f -x -d -e ".nim_runtime"
           nim prettyfy
 
       - name: Fail if needs reformatting

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Format code
         run: |
+          echo ".nim_runtime" >> .gitignore
           git clean -f -x -d
           nim prettyfy
 

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -20,8 +20,9 @@ jobs:
 
       - uses: jiro4989/setup-nim-action@v2
         with:
+          nim-version: '2.0.8'  # default is stable
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          nim-install-directory: ${{ runner.temp }}/nim_runtime
+          nim-install-directory: ${{ runner.temp }}
 
       - name: Format code
         run: |

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           nim-version: '2.0.8'  # default is stable
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          nim-install-directory: /home/runner/
+          parent-nim-install-directory: /home/runner/
 
       - name: Format code
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nimcache/
 nimblecache/
 htmldocs/
+.nim_runtime

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 nimcache/
 nimblecache/
 htmldocs/
-.nim_runtime


### PR DESCRIPTION
The directory `.nim_runtime` created by the new version of the github action `setup-nim-action` must be escaped by all commands including nim prettyfy.

I can not merge this PR myself, so please have a look at it @Panquesito7  as soon as it is validated by e.g. @vil02 
