### PR TITLE
Chore: fix build_directory_md.yml

### DIFF
--- a/.github/workflows/build_directory_md.yml
+++ b/.github/workflows/build_directory_md.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Build file
         run: |
-          git clean -f -x -d
+          git clean -f -x -d --exclude=".nim_runtime"
 
           # Compile the script first
           nim c -o:directory_script .scripts/directory.nim

--- a/.github/workflows/build_directory_md.yml
+++ b/.github/workflows/build_directory_md.yml
@@ -19,10 +19,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: jiro4989/setup-nim-action@v2
+        with:
+          parent-nim-install-directory: ${{ runner.temp }}
 
       - name: Build file
         run: |
-          git clean -f -x -d --exclude=".nim_runtime"
+          git clean --force -x -d
 
           # Compile the script first
           nim c -o:directory_script .scripts/directory.nim


### PR DESCRIPTION
Fixes the `build_directory_md.yml` action. ~~Sets the Nim runtime dir as a forced git exclusion~~.

`git clean` removed the nim compiler directory, which `jiro4989/setup-nim-action@v2` installs to `$(pwd)/.nim_runtime`.

This puts the nim install dir outside of the current project directory with:

```yml
  - uses: jiro4989/setup-nim-action@v2
    with:
      parent-nim-install-directory: ${{ runner.temp }}
```