### PR TITLE
Fix and clean CI after Nim 2.2.0 update

### DIFF
--- a/maths/modular_inverse.nim
+++ b/maths/modular_inverse.nim
@@ -67,7 +67,7 @@ when isMainModule:
       check modularInverse(17, 17).is_none()
 
     randomize()
-    const randomTestSize = 1000
+    const randomTestSize = 10
     for testNum in 0..randomTestSize:
       let a = rand(-10000000..10000000)
       let modulus = rand(1..1000000)

--- a/strings/check_anagram.nim
+++ b/strings/check_anagram.nim
@@ -59,7 +59,7 @@ func toLowerUnchecked(c: char): char {.inline.} =
   # 0b100_0001, so setting the sixth bit to 1 gives letter's lowercase pair.
   char(uint8(c) or 0b0010_0000'u8)
 
-template normalizeChar(c: char) =
+template normalizeChar(c: char): char =
   ## Checks if the character is a letter and lowers its case.
   ##
   ## Raises a `ValueError` on other characters.


### PR DESCRIPTION
- **Specify template's return type for correct variable declaration**
I specified the return type of a template in strings/check_anagram.nim
There was an error about non-discarded char elements, as somehow these values were not considered part of the declaration.
I am not super fan of this fix, as one branch of the case switch just errors out and do not return a value. I am all ears for a better fix.

- **[modular_inverse] Reduce the number of tests to make CI readable again**
The CI was not very readable due to a too great number of tests in the maths/modular_inverse.nim file. I reduced the number of tests from 1000 to 10.
