### PR TITLE
chore: use nim version `2.2.4`

### DIFF
--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '2.2.2'
+          - '2.2.4'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[Nim 2.2.4](https://nim-lang.org/blog/2025/04/22/nim-224-2016.html) was released.

Similar to #73.