### PR TITLE
chore: use nim version `2.2.6`

### DIFF
--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '2.2.4'
+          - '2.2.6'
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
[Nim 2.2.6](https://nim-lang.org/blog/2025/10/31/nim-226.html) was released.

Similar to #73.