### PR TITLE
chore: use nim version `2.2.10`

### DIFF
--- a/.github/workflows/nim_test.yml
+++ b/.github/workflows/nim_test.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-latest
           - windows-latest
         nim-version:
-          - '2.2.8'
+          - '2.2.10'
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
[Nim 2.2.10](https://nim-lang.org/blog/2026/04/24/nim-2210.html) was released.

Similar to #73.